### PR TITLE
Multiple tweaks to the firehol

### DIFF
--- a/puppet/modules/firehol/manifests/dnat4.pp
+++ b/puppet/modules/firehol/manifests/dnat4.pp
@@ -14,6 +14,6 @@ define firehol::dnat4 (
   concat::fragment { "dnat4_${title}":
     target  => $config_file,
     content => template('firehol/firehol_dnat4.erb'),
-    order   => '00',
+    order   => '02',
   }
 }

--- a/puppet/modules/firehol/manifests/init.pp
+++ b/puppet/modules/firehol/manifests/init.pp
@@ -24,7 +24,7 @@ class firehol (
     require => Package['firehol'],
     target  => $config_file,
     content => template('firehol/firehol_header.erb'),
-    order   => '01',
+    order   => '00',
   }
 
   file { '/etc/default/firehol':

--- a/puppet/modules/firehol/manifests/ipv6.pp
+++ b/puppet/modules/firehol/manifests/ipv6.pp
@@ -1,0 +1,14 @@
+# Resource for a FireHOL Interface
+#
+# @param variable Name of the variable, e.g. FIREHOL_ENABLE_SPINNER.
+# @param value The value of the variable
+# @param config_file String param, which config file to work with. Defaults to '/etc/firehol/firehol.con'.
+define firehol::ipv6 (
+  String                           $config_file    = '/etc/firehol/firehol.conf',
+) {
+  concat::fragment { "firehol_ipv6":
+    target  => $config_file,
+    content => template('firehol/firehol_ipv6.erb'),
+    order   => '03',
+  }
+}

--- a/puppet/modules/firehol/manifests/ipv6.pp
+++ b/puppet/modules/firehol/manifests/ipv6.pp
@@ -1,7 +1,5 @@
 # Resource for a FireHOL Interface
 #
-# @param variable Name of the variable, e.g. FIREHOL_ENABLE_SPINNER.
-# @param value The value of the variable
 # @param config_file String param, which config file to work with. Defaults to '/etc/firehol/firehol.con'.
 define firehol::ipv6 (
   String                           $config_file    = '/etc/firehol/firehol.conf',

--- a/puppet/modules/firehol/manifests/variable.pp
+++ b/puppet/modules/firehol/manifests/variable.pp
@@ -1,0 +1,16 @@
+# Resource for a FireHOL Interface
+#
+# @param variable Name of the variable, e.g. FIREHOL_ENABLE_SPINNER.
+# @param value The value of the variable
+# @param config_file String param, which config file to work with. Defaults to '/etc/firehol/firehol.con'.
+define firehol::variable (
+  String                           $variable,
+  String                           $value,
+  String                           $config_file    = '/etc/firehol/firehol.conf',
+) {
+  concat::fragment { "variable_${variable}":
+    target  => $config_file,
+    content => template('firehol/firehol_variable.erb'),
+    order   => '01',
+  }
+}

--- a/puppet/modules/firehol/templates/firehol_header.erb
+++ b/puppet/modules/firehol/templates/firehol_header.erb
@@ -1,11 +1,3 @@
 # This File is managed by Puppet
 version 6
 
-ipv6 interface any v6interop proto icmpv6
-	client ipv6neigh accept
-	server ipv6neigh accept
-	client ipv6mld accept
-	client ipv6router accept
-	policy return
-
-

--- a/puppet/modules/firehol/templates/firehol_ipv6.erb
+++ b/puppet/modules/firehol/templates/firehol_ipv6.erb
@@ -1,0 +1,6 @@
+ipv6 interface any v6interop proto icmpv6
+    client ipv6neigh accept
+    server ipv6neigh accept
+    client ipv6mld accept
+    client ipv6router accept
+    policy return

--- a/puppet/modules/firehol/templates/firehol_variable.erb
+++ b/puppet/modules/firehol/templates/firehol_variable.erb
@@ -1,0 +1,1 @@
+<%= @variable %>="<%= @value %>"

--- a/puppet/modules/role/manifests/lxc.pp
+++ b/puppet/modules/role/manifests/lxc.pp
@@ -34,72 +34,114 @@ class role::lxc (
     class { 'firehol':
         ensure => true,
     }
+
+    firehol::variable { 'FIREHOL_ENABLE_SPINNER': 
+      variable => 'FIREHOL_ENABLE_SPINNER',
+      value    => '1'
+    }
+
+    firehol::variable { 'FIREHOL_FAST_ACTIVATION': 
+      variable => 'FIREHOL_FAST_ACTIVATION',
+      value    => '1'
+    }
+
+    firehol::variable { 'FIREHOL_LOG_MODE': 
+      variable => 'FIREHOL_LOG_MODE',
+      value    => 'NFLOG'
+    }
+
+    firehol::variable { 'FIREHOL_LOG_FREQUENCY': 
+      variable => 'FIREHOL_LOG_FREQUENCY',
+      value    => '10/second'
+    }
+
+    firehol::variable { 'FIREHOL_LOG_BURST': 
+      variable => 'FIREHOL_LOG_BURST',
+      value    => '60'
+    }
+
+    firehol::variable { 'DEFAULT_CLIENT_PORTS': 
+      variable => 'DEFAULT_CLIENT_PORTS',
+      value    => '0:65535'
+    }
+
+    firehol::variable { 'FIREHOL_DROP_ORPHAN_TCP_ACK_FIN': 
+      variable => 'FIREHOL_DROP_ORPHAN_TCP_ACK_FIN',
+      value    => '1'
+    }
+
     firehol::dnat4 { 'http':
         interface => $public_interface,
         backend   => '10.1.1.20',
         matches   => 'proto tcp dport "80 443"',
     }
+
     firehol::dnat4 { 'vpn-tcp':
         interface => $public_interface,
         backend   => '10.1.1.100',
         matches   => 'proto tcp dport 1194',
     }
+
     firehol::dnat4 { 'vpn-udp':
         interface => $public_interface,
         backend   => '10.1.1.100',
         matches   => 'proto udp dport 1194',
     }
+
     firehol::dnat4 { 'mail':
         interface => $public_interface,
         backend   => '10.1.1.110',
         matches   => 'proto tcp dport "25 465 110 143 993 995 587"',
     }
+
     firehol::dnat4 { 'ftp':
         interface => $public_interface,
         backend   => '10.1.1.20',
         matches   => 'proto tcp dport "20 21"',
     }
+
     firehol::interface { $public_interface: interface_name => 'public', }
+
     firehol::interface { $lxc_bridge: interface_name => 'private', }
+
     firehol::router { 'lxc_router':
         inface  => $lxc_bridge,
         outface => $public_interface,
     }
-    firehol::service { 'ssh': server => 'tcp/22,2222', }
-    firehol::service { 'mysql': server => 'tcp/3306', }
-    firehol::service { 'mail': server => 'tcp/25,465,110,143,993,995', }
-    firehol::service { 'web': server => 'tcp/80,443', }
-    firehol::service { 'dns': server => 'tcp/53,udp/53', }
-    firehol::service { 'openvpn': server => 'tcp/1194,udp/1194', }
-    firehol::service { 'ftp': server => 'tcp/20,21', }
-    firehol::service { 'rsync': server => 'tcp/873', }
+
+    firehol::service { 'sshalt': server => 'tcp/2222', }
 
     firehol::rule { 'public-server':
         interface => $public_interface,
         direction => 'server',
-        service   => ['icmp', 'mail', 'ssh', 'web', 'openvpn', 'ftp'],
+        service   => ['icmp', 'smtp', 'smtps', 'imap', 'imaps', 'sshalt', 'http', 'https', 'openvpn', 'ftp'],
     }
+
     firehol::rule { 'public-client':
         interface => $public_interface,
         direction => 'client',
         service   => 'all',
     }
+
     firehol::rule { 'bridge-server':
         interface => $lxc_bridge,
         direction => 'server',
-        service   => ['icmp', 'mail', 'ssh', 'web'],
+        service   => ['icmp', 'sshalt', 'http', 'https'],
     }
+
     firehol::rule { 'bridge-client':
         interface => $lxc_bridge,
         direction => 'client',
         service   => 'all',
     }
+
     firehol::router_rule { 'masquerade':
         router    => 'lxc_router',
         direction => '',
         action    => 'masquerade',
         service   => '',
     }
+
     firehol::router_rule { 'route_all':
         router    => 'lxc_router',
         direction => 'route',
@@ -116,11 +158,12 @@ class role::lxc (
         }
     }
 
-
     class { 'rsync::server':
         use_xinetd => false,
     }
+
     # LXC configuration, dependent on master/slave
+
     class { 'lxc':
         lxc_networking_device_link    => $lxc_bridge,
         lxc_networking_type           => 'veth',
@@ -146,6 +189,7 @@ class role::lxc (
         ],
         storage_backend => 'dir',
     }
+
     $lxc_interface_defaults = {
         device_name  => 'eth0',
         ensure       => present,

--- a/puppet/modules/role/manifests/lxc.pp
+++ b/puppet/modules/role/manifests/lxc.pp
@@ -100,6 +100,10 @@ class role::lxc (
         matches   => 'proto tcp dport "20 21"',
     }
 
+    firehol::ipv6 { 'ipv6': 
+
+    }
+
     firehol::interface { $public_interface: interface_name => 'public', }
 
     firehol::interface { $lxc_bridge: interface_name => 'private', }


### PR DESCRIPTION
Removes the not needed ipv6 declaration from the header
Adds a variable module to allow for firehol variables needed
Cleans up the firehol build code
Changes the order of the firehol modules